### PR TITLE
Bugfix/UI update on scale

### DIFF
--- a/lib/src/configuration/better_player_controller_event.dart
+++ b/lib/src/configuration/better_player_controller_event.dart
@@ -13,5 +13,8 @@ enum BetterPlayerControllerEvent {
   setupDataSource,
 
   //Video has started.
-  play
+  play,
+
+  /// Changed the fit of the video widget
+  fitChanged,
 }

--- a/lib/src/configuration/better_player_controller_event.dart
+++ b/lib/src/configuration/better_player_controller_event.dart
@@ -16,5 +16,5 @@ enum BetterPlayerControllerEvent {
   play,
 
   /// Changed the fit of the video widget
-  changedFit,
+  changeFit,
 }

--- a/lib/src/configuration/better_player_controller_event.dart
+++ b/lib/src/configuration/better_player_controller_event.dart
@@ -16,5 +16,5 @@ enum BetterPlayerControllerEvent {
   play,
 
   /// Changed the fit of the video widget
-  fitChanged,
+  changedFit,
 }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1043,7 +1043,7 @@ class BetterPlayerController {
   ///Setup overridden fit.
   void setOverriddenFit(BoxFit fit) {
     _overriddenFit = fit;
-    _postControllerEvent(BetterPlayerControllerEvent.changedFit);
+    _postControllerEvent(BetterPlayerControllerEvent.changeFit);
   }
 
   ///Get fit used in current video. If fit is null, then fit from

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1043,6 +1043,7 @@ class BetterPlayerController {
   ///Setup overridden fit.
   void setOverriddenFit(BoxFit fit) {
     _overriddenFit = fit;
+    _postControllerEvent(BetterPlayerControllerEvent.changedFit);
   }
 
   ///Get fit used in current video. If fit is null, then fit from


### PR DESCRIPTION
**before**: UI wouldn't be updated if the fit was changed in controller.
**after**: Added new enum element `BetterPlayerControllerEvent.changeFit` and posting it by the controller so UI gets updated as it is the `default` case. From the state of `BetterPlayer` widget:
```dart
...
  void onControllerEvent(BetterPlayerControllerEvent event) {
    switch (event) {
      case BetterPlayerControllerEvent.openFullscreen:
        onFullScreenChanged();
        break;
      case BetterPlayerControllerEvent.hideFullscreen:
        onFullScreenChanged();
        break;
      default:
        setState(() {});
        break;
    }
  }
...
``` 