### PR TITLE
Fix player `Progress` event being sent when video is not playing (i.e…

### DIFF
--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -804,15 +804,17 @@ class BetterPlayerController {
     final int now = DateTime.now().millisecondsSinceEpoch;
     if (now - _lastPositionSelection > 500) {
       _lastPositionSelection = now;
-      _postEvent(
-        BetterPlayerEvent(
-          BetterPlayerEventType.progress,
-          parameters: <String, dynamic>{
-            _progressParameter: currentVideoPlayerValue.position,
-            _durationParameter: currentVideoPlayerValue.duration
-          },
-        ),
-      );
+      if (videoPlayerController?.value.isPlaying ?? false) {
+        _postEvent(
+          BetterPlayerEvent(
+            BetterPlayerEventType.progress,
+            parameters: <String, dynamic>{
+              _progressParameter: currentVideoPlayerValue.position,
+              _durationParameter: currentVideoPlayerValue.duration
+            },
+          ),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Requested: fix pause banner glitch after scrolling through video timestamps
After: Fix player Progress event being sent when video is not playing (i.e, on pause), which fixed pause banner glitch

Task reference: https://appraiders.atlassian.net/browse/MLABMOB-1361