### PR TITLE
Feature/add setter to change full screen by default parameter

### DIFF
--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -208,7 +208,10 @@ class BetterPlayerController {
   final List<String> _asmsSegmentsLoaded = [];
 
   ///Currently displayed [BetterPlayerSubtitle].
-  BetterPlayerSubtitle? renderedSubtitle;
+  BetterPlayerSubtitle? renderedSubtitle; 
+  
+  ///Whether the player by default enters full screen mode
+  bool? _fullScreenByDefault;
 
   BetterPlayerController(
     this.betterPlayerConfiguration, {
@@ -555,7 +558,7 @@ class BetterPlayerController {
         ?.videoEventStreamController.stream
         .listen(_handleVideoEvent);
 
-    final fullScreenByDefault = betterPlayerConfiguration.fullScreenByDefault;
+    final fullScreenByDefault = _fullScreenByDefault ?? betterPlayerConfiguration.fullScreenByDefault;
     if (betterPlayerConfiguration.autoPlay) {
       if (fullScreenByDefault && !isFullScreen) {
         enterFullScreen();
@@ -588,6 +591,11 @@ class BetterPlayerController {
       enterFullScreen();
       videoPlayerController?.removeListener(_onFullScreenStateChanged);
     }
+  } 
+
+  ///Enable/Disable full screen by default parameter 
+  void setFullScreenByDefault(bool enable) {
+    _fullScreenByDefault = enable;
   }
 
   ///Enables full screen mode in player. This will trigger route change.


### PR DESCRIPTION
requested:
if before buffering configuration changes, the player was in windowed mode, it shouldn't enter full screen mode
after:
player saves the last screen mode (full or windowed) and applies on configuration change

tasklink:
https://appraiders.atlassian.net/browse/MLABMOB-1682